### PR TITLE
bug/interlok-3167

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,6 @@ log4j.properties
 *.orig
 target
 bin
+out
 .gradle
 gradle.properties

--- a/src/main/java/com/adaptris/security/pgp/PGPDecryptService.java
+++ b/src/main/java/com/adaptris/security/pgp/PGPDecryptService.java
@@ -13,7 +13,15 @@ import com.adaptris.interlok.config.DataOutputParameter;
 import com.adaptris.interlok.resolver.ExternalResolver;
 import com.adaptris.security.password.Password;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-import org.bouncycastle.openpgp.*;
+import org.bouncycastle.openpgp.PGPCompressedData;
+import org.bouncycastle.openpgp.PGPEncryptedDataList;
+import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.PGPLiteralData;
+import org.bouncycastle.openpgp.PGPOnePassSignatureList;
+import org.bouncycastle.openpgp.PGPPrivateKey;
+import org.bouncycastle.openpgp.PGPPublicKeyEncryptedData;
+import org.bouncycastle.openpgp.PGPSecretKey;
+import org.bouncycastle.openpgp.PGPSecretKeyRingCollection;
 import org.bouncycastle.openpgp.jcajce.JcaPGPObjectFactory;
 import org.bouncycastle.openpgp.operator.jcajce.JcaKeyFingerprintCalculator;
 import org.bouncycastle.openpgp.operator.jcajce.JcePBESecretKeyDecryptorBuilder;
@@ -227,7 +235,7 @@ public class PGPDecryptService extends PGPService
 		{
 			throw new IllegalArgumentException("Secret key for message not found");
 		}
-		InputStream clear = pbe.getDataStream(new JcePublicKeyDataDecryptorFactoryBuilder().setProvider("BC").build(sKey));
+		InputStream clear = pbe.getDataStream(new JcePublicKeyDataDecryptorFactoryBuilder().setProvider(PROVIDER).build(sKey));
 		JcaPGPObjectFactory plainFact = new JcaPGPObjectFactory(clear);
 		PGPCompressedData cData = (PGPCompressedData)plainFact.nextObject();
 		try (InputStream compressedStream = new BufferedInputStream(cData.getDataStream()))
@@ -286,6 +294,6 @@ public class PGPDecryptService extends PGPService
 		{
 			return null;
 		}
-		return pgpSecKey.extractPrivateKey(new JcePBESecretKeyDecryptorBuilder().setProvider("BC").build(pass));
+		return pgpSecKey.extractPrivateKey(new JcePBESecretKeyDecryptorBuilder().setProvider(PROVIDER).build(pass));
 	}
 }

--- a/src/main/java/com/adaptris/security/pgp/PGPEncryptService.java
+++ b/src/main/java/com/adaptris/security/pgp/PGPEncryptService.java
@@ -15,7 +15,16 @@ import com.adaptris.interlok.config.DataOutputParameter;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import org.apache.commons.lang3.BooleanUtils;
 import org.bouncycastle.bcpg.ArmoredOutputStream;
-import org.bouncycastle.openpgp.*;
+import org.bouncycastle.openpgp.PGPCompressedData;
+import org.bouncycastle.openpgp.PGPCompressedDataGenerator;
+import org.bouncycastle.openpgp.PGPEncryptedData;
+import org.bouncycastle.openpgp.PGPEncryptedDataGenerator;
+import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.PGPLiteralData;
+import org.bouncycastle.openpgp.PGPLiteralDataGenerator;
+import org.bouncycastle.openpgp.PGPPublicKey;
+import org.bouncycastle.openpgp.PGPPublicKeyRing;
+import org.bouncycastle.openpgp.PGPPublicKeyRingCollection;
 import org.bouncycastle.openpgp.operator.jcajce.JcaKeyFingerprintCalculator;
 import org.bouncycastle.openpgp.operator.jcajce.JcePGPDataEncryptorBuilder;
 import org.bouncycastle.openpgp.operator.jcajce.JcePublicKeyKeyEncryptionMethodGenerator;
@@ -88,6 +97,8 @@ public class PGPEncryptService extends PGPService
 	@InputFieldDefault(value = "true")
 	private Boolean integrityCheck = true;
 
+	private String id;
+
 	/**
 	 * {@inheritDoc}.
 	 */
@@ -99,6 +110,7 @@ public class PGPEncryptService extends PGPService
 			InputStream key = extractStream(message, publicKey, "Could not read public key");
 			InputStream clear = extractStream(message, clearText, "Could not read clear text message to encrypt");
 			ByteArrayOutputStream cipher = new ByteArrayOutputStream();
+			id = message.getUniqueId();
 			encrypt(clear, cipher, key, armorEncoding, integrityCheck);
 			insertStream(message, cipherText, cipher);
 		}
@@ -220,17 +232,17 @@ public class PGPEncryptService extends PGPService
 	 * @throws PGPException Thrown if there's a problem with the key/passphrase.
 	 * @throws IOException  Thrown if there's an IO issue.
 	 */
-	private static void encrypt(InputStream in, OutputStream out, InputStream encKey, boolean armor, boolean withIntegrityCheck) throws PGPException, IOException
+	private void encrypt(InputStream in, OutputStream out, InputStream encKey, boolean armor, boolean withIntegrityCheck) throws PGPException, IOException
 	{
 		if (armor)
 		{
 			out = new ArmoredOutputStream(out);
 		}
 		/* TODO cipher could be an advanced option */
-		PGPEncryptedDataGenerator cPk = new PGPEncryptedDataGenerator(new JcePGPDataEncryptorBuilder(PGPEncryptedData.AES_256).setWithIntegrityPacket(withIntegrityCheck).setSecureRandom(new SecureRandom()).setProvider("BC"));
-		cPk.addMethod(new JcePublicKeyKeyEncryptionMethodGenerator(readPublicKey(encKey)).setProvider("BC"));
+		PGPEncryptedDataGenerator cPk = new PGPEncryptedDataGenerator(new JcePGPDataEncryptorBuilder(PGPEncryptedData.AES_256).setWithIntegrityPacket(withIntegrityCheck).setSecureRandom(new SecureRandom()).setProvider(PROVIDER));
+		cPk.addMethod(new JcePublicKeyKeyEncryptionMethodGenerator(readPublicKey(encKey)).setProvider(PROVIDER));
 		OutputStream cOut = cPk.open(out, new byte[1 << 16]);
-		PGPCompressedDataGenerator comData = new PGPCompressedDataGenerator(PGPCompressedData.ZIP);
+		PGPCompressedDataGenerator comData = new PGPCompressedDataGenerator(PGPCompressedData.UNCOMPRESSED);
 		writeFileToLiteralData(in, comData.open(cOut), PGPLiteralData.BINARY, new byte[1 << 16]);
 		comData.close();
 		cOut.close();
@@ -284,31 +296,21 @@ public class PGPEncryptService extends PGPService
 	 * @throws IOException if an error occurs reading the file or writing to the output stream.
 	 * @see PGPLiteralDataGenerator#open(OutputStream, char, String, Date, byte[])
 	 */
-	private static void writeFileToLiteralData(InputStream in, OutputStream out, char fileType, byte[] buffer) throws IOException
+	private void writeFileToLiteralData(InputStream in, OutputStream out, char fileType, byte[] buffer) throws IOException
 	{
 		PGPLiteralDataGenerator lData = new PGPLiteralDataGenerator();
-		OutputStream pOut = lData.open(out, fileType, in.toString(), new Date(), buffer);
 		byte[] buf = new byte[buffer.length];
-		try
+		try (OutputStream pOut = lData.open(out, fileType, id, new Date(), buffer))
 		{
 			int len;
 			while ((len = in.read(buf)) > 0)
 			{
 				pOut.write(buf, 0, len);
 			}
-			pOut.close();
 		}
 		finally
 		{
 			Arrays.fill(buf, (byte)0);
-			try
-			{
-				in.close();
-			}
-			catch (IOException ignored)
-			{
-				// ignore...
-			}
 		}
 	}
 }

--- a/src/main/java/com/adaptris/security/pgp/PGPEncryptService.java
+++ b/src/main/java/com/adaptris/security/pgp/PGPEncryptService.java
@@ -97,9 +97,7 @@ public class PGPEncryptService extends PGPService
 	@InputFieldDefault(value = "true")
 	private Boolean integrityCheck = true;
 
-	private String id;
-
-	/**
+		/**
 	 * {@inheritDoc}.
 	 */
 	@Override
@@ -110,8 +108,8 @@ public class PGPEncryptService extends PGPService
 			InputStream key = extractStream(message, publicKey, "Could not read public key");
 			InputStream clear = extractStream(message, clearText, "Could not read clear text message to encrypt");
 			ByteArrayOutputStream cipher = new ByteArrayOutputStream();
-			id = message.getUniqueId();
-			encrypt(clear, cipher, key, armorEncoding, integrityCheck);
+			String id = message.getUniqueId();
+			encrypt(id, clear, cipher, key, armorEncoding, integrityCheck);
 			insertStream(message, cipherText, cipher);
 		}
 		catch (Exception e)
@@ -232,7 +230,7 @@ public class PGPEncryptService extends PGPService
 	 * @throws PGPException Thrown if there's a problem with the key/passphrase.
 	 * @throws IOException  Thrown if there's an IO issue.
 	 */
-	private void encrypt(InputStream in, OutputStream out, InputStream encKey, boolean armor, boolean withIntegrityCheck) throws PGPException, IOException
+	private void encrypt(String id, InputStream in, OutputStream out, InputStream encKey, boolean armor, boolean withIntegrityCheck) throws PGPException, IOException
 	{
 		if (armor)
 		{
@@ -243,7 +241,7 @@ public class PGPEncryptService extends PGPService
 		cPk.addMethod(new JcePublicKeyKeyEncryptionMethodGenerator(readPublicKey(encKey)).setProvider(PROVIDER));
 		OutputStream cOut = cPk.open(out, new byte[1 << 16]);
 		PGPCompressedDataGenerator comData = new PGPCompressedDataGenerator(PGPCompressedData.ZIP);
-		writeFileToLiteralData(in, comData.open(cOut), PGPLiteralData.BINARY, new byte[1 << 16]);
+		writeFileToLiteralData(id, in, comData.open(cOut), PGPLiteralData.BINARY, new byte[1 << 16]);
 		comData.close();
 		cOut.close();
 		if (armor)
@@ -296,7 +294,7 @@ public class PGPEncryptService extends PGPService
 	 * @throws IOException if an error occurs reading the file or writing to the output stream.
 	 * @see PGPLiteralDataGenerator#open(OutputStream, char, String, Date, byte[])
 	 */
-	private void writeFileToLiteralData(InputStream in, OutputStream out, char fileType, byte[] buffer) throws IOException
+	private void writeFileToLiteralData(String id, InputStream in, OutputStream out, char fileType, byte[] buffer) throws IOException
 	{
 		PGPLiteralDataGenerator lData = new PGPLiteralDataGenerator();
 		byte[] buf = new byte[buffer.length];

--- a/src/main/java/com/adaptris/security/pgp/PGPEncryptService.java
+++ b/src/main/java/com/adaptris/security/pgp/PGPEncryptService.java
@@ -242,7 +242,7 @@ public class PGPEncryptService extends PGPService
 		PGPEncryptedDataGenerator cPk = new PGPEncryptedDataGenerator(new JcePGPDataEncryptorBuilder(PGPEncryptedData.AES_256).setWithIntegrityPacket(withIntegrityCheck).setSecureRandom(new SecureRandom()).setProvider(PROVIDER));
 		cPk.addMethod(new JcePublicKeyKeyEncryptionMethodGenerator(readPublicKey(encKey)).setProvider(PROVIDER));
 		OutputStream cOut = cPk.open(out, new byte[1 << 16]);
-		PGPCompressedDataGenerator comData = new PGPCompressedDataGenerator(PGPCompressedData.UNCOMPRESSED);
+		PGPCompressedDataGenerator comData = new PGPCompressedDataGenerator(PGPCompressedData.ZIP);
 		writeFileToLiteralData(in, comData.open(cOut), PGPLiteralData.BINARY, new byte[1 << 16]);
 		comData.close();
 		cOut.close();

--- a/src/main/java/com/adaptris/security/pgp/PGPService.java
+++ b/src/main/java/com/adaptris/security/pgp/PGPService.java
@@ -86,6 +86,10 @@ abstract class PGPService extends ServiceImp
 		{
 			param = new ByteArrayInputStream(((String)param).getBytes(getEncoding(message)));
 		}
+		if (param instanceof byte[])
+		{
+			param = new ByteArrayInputStream((byte[])param);
+		}
 		if (!(param instanceof InputStream))
 		{
 			throw new InterlokException(warning);
@@ -101,6 +105,12 @@ abstract class PGPService extends ServiceImp
 		{
 			ByteArrayOutputStream baos = new ByteArrayOutputStream();
 			IOUtils.copy((InputStream)param, baos);
+			param = baos.toString(getEncoding(message));
+		}
+		if (param instanceof byte[])
+		{
+			ByteArrayOutputStream baos = new ByteArrayOutputStream();
+			baos.write((byte[])param);
 			param = baos.toString(getEncoding(message));
 		}
 		if (!(param instanceof String))

--- a/src/main/java/com/adaptris/security/pgp/PGPService.java
+++ b/src/main/java/com/adaptris/security/pgp/PGPService.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.security.Security;
 import java.security.SignatureException;
 
@@ -351,6 +352,10 @@ abstract class PGPService extends ServiceImp
 		if (encoding == null)
 		{
 			encoding = message.getFactory().getDefaultCharEncoding();
+		}
+		if (encoding == null)
+		{
+			encoding = Charset.defaultCharset().toString();
 		}
 		return encoding;
 	}

--- a/src/main/java/com/adaptris/security/pgp/PGPService.java
+++ b/src/main/java/com/adaptris/security/pgp/PGPService.java
@@ -4,6 +4,8 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceImp;
 import com.adaptris.core.common.InputStreamWithEncoding;
 import com.adaptris.core.common.PayloadStreamOutputParameter;
+import com.adaptris.core.common.StringPayloadDataOutputParameter;
+import com.adaptris.core.common.ByteArrayPayloadDataOutputParameter;
 import com.adaptris.interlok.InterlokException;
 import com.adaptris.interlok.config.DataInputParameter;
 import com.adaptris.interlok.config.DataOutputParameter;
@@ -122,15 +124,19 @@ abstract class PGPService extends ServiceImp
 
 	protected void insertStream(AdaptrisMessage message, DataOutputParameter parameter, ByteArrayOutputStream value) throws Exception
 	{
-		try
+		if (parameter instanceof StringPayloadDataOutputParameter)
 		{
 			parameter.insert(value.toString(getEncoding(message)), message);
 		}
-		catch (ClassCastException e)
+		else if (parameter instanceof PayloadStreamOutputParameter)
 		{
 			// force no character encoding; data is raw bytes
 			((PayloadStreamOutputParameter)parameter).setContentEncoding(null);
 			parameter.insert(new InputStreamWithEncoding(new ByteArrayInputStream(value.toByteArray()), null), message);
+		}
+		else if (parameter instanceof ByteArrayPayloadDataOutputParameter)
+		{
+			parameter.insert(value.toByteArray(), message);
 		}
 	}
 

--- a/src/main/java/com/adaptris/security/pgp/PGPSignService.java
+++ b/src/main/java/com/adaptris/security/pgp/PGPSignService.java
@@ -19,14 +19,7 @@ import org.apache.commons.lang3.BooleanUtils;
 import org.bouncycastle.bcpg.ArmoredOutputStream;
 import org.bouncycastle.bcpg.BCPGOutputStream;
 import org.bouncycastle.bcpg.HashAlgorithmTags;
-import org.bouncycastle.openpgp.PGPException;
-import org.bouncycastle.openpgp.PGPPrivateKey;
-import org.bouncycastle.openpgp.PGPSecretKey;
-import org.bouncycastle.openpgp.PGPSecretKeyRing;
-import org.bouncycastle.openpgp.PGPSecretKeyRingCollection;
-import org.bouncycastle.openpgp.PGPSignature;
-import org.bouncycastle.openpgp.PGPSignatureGenerator;
-import org.bouncycastle.openpgp.PGPSignatureSubpacketGenerator;
+import org.bouncycastle.openpgp.*;
 import org.bouncycastle.openpgp.operator.jcajce.JcaKeyFingerprintCalculator;
 import org.bouncycastle.openpgp.operator.jcajce.JcaPGPContentSignerBuilder;
 import org.bouncycastle.openpgp.operator.jcajce.JcePBESecretKeyDecryptorBuilder;
@@ -334,13 +327,15 @@ public class PGPSignService extends PGPService
 		PGPPrivateKey pgpPrivKey = pgpSec.extractPrivateKey(new JcePBESecretKeyDecryptorBuilder().setProvider(PROVIDER).build(passwd));
 		PGPSignatureGenerator sGen = new PGPSignatureGenerator(new JcaPGPContentSignerBuilder(pgpSec.getPublicKey().getAlgorithm(), digest).setProvider(PROVIDER));
 		sGen.init(PGPSignature.BINARY_DOCUMENT, pgpPrivKey);
-		BCPGOutputStream bOut = new BCPGOutputStream(out);
+		PGPCompressedDataGenerator comData = new PGPCompressedDataGenerator(PGPCompressedData.ZIP);
+		BCPGOutputStream bOut = new BCPGOutputStream(comData.open(out));
 		int ch;
 		while ((ch = in.read()) >= 0)
 		{
 			sGen.update((byte)ch);
 		}
 		sGen.generate().encode(bOut);
+		comData.close();
 		if (armor)
 		{
 			out.close();

--- a/src/main/java/com/adaptris/security/pgp/PGPSignService.java
+++ b/src/main/java/com/adaptris/security/pgp/PGPSignService.java
@@ -275,8 +275,8 @@ public class PGPSignService extends PGPService
 	private static void sign(InputStream in, InputStream key, char[] passwd, int digest, OutputStream out) throws PGPException, IOException, SignatureException
 	{
 		PGPSecretKey pgpSec = readSecretKey(key);
-		PGPPrivateKey pgpPrivKey = pgpSec.extractPrivateKey(new JcePBESecretKeyDecryptorBuilder().setProvider("BC").build(passwd));
-		PGPSignatureGenerator sGen = new PGPSignatureGenerator(new JcaPGPContentSignerBuilder(pgpSec.getPublicKey().getAlgorithm(), digest).setProvider("BC"));
+		PGPPrivateKey pgpPrivKey = pgpSec.extractPrivateKey(new JcePBESecretKeyDecryptorBuilder().setProvider(PROVIDER).build(passwd));
+		PGPSignatureGenerator sGen = new PGPSignatureGenerator(new JcaPGPContentSignerBuilder(pgpSec.getPublicKey().getAlgorithm(), digest).setProvider(PROVIDER));
 		PGPSignatureSubpacketGenerator spGen = new PGPSignatureSubpacketGenerator();
 		sGen.init(PGPSignature.CANONICAL_TEXT_DOCUMENT, pgpPrivKey);
 		Iterator it = pgpSec.getPublicKey().getUserIDs();
@@ -331,8 +331,8 @@ public class PGPSignService extends PGPService
 			out = new ArmoredOutputStream(out);
 		}
 		PGPSecretKey pgpSec = readSecretKey(key);
-		PGPPrivateKey pgpPrivKey = pgpSec.extractPrivateKey(new JcePBESecretKeyDecryptorBuilder().setProvider("BC").build(passwd));
-		PGPSignatureGenerator sGen = new PGPSignatureGenerator(new JcaPGPContentSignerBuilder(pgpSec.getPublicKey().getAlgorithm(), digest).setProvider("BC"));
+		PGPPrivateKey pgpPrivKey = pgpSec.extractPrivateKey(new JcePBESecretKeyDecryptorBuilder().setProvider(PROVIDER).build(passwd));
+		PGPSignatureGenerator sGen = new PGPSignatureGenerator(new JcaPGPContentSignerBuilder(pgpSec.getPublicKey().getAlgorithm(), digest).setProvider(PROVIDER));
 		sGen.init(PGPSignature.BINARY_DOCUMENT, pgpPrivKey);
 		BCPGOutputStream bOut = new BCPGOutputStream(out);
 		int ch;

--- a/src/main/java/com/adaptris/security/pgp/PGPSignService.java
+++ b/src/main/java/com/adaptris/security/pgp/PGPSignService.java
@@ -328,17 +328,19 @@ public class PGPSignService extends PGPService
 		PGPSignatureGenerator sGen = new PGPSignatureGenerator(new JcaPGPContentSignerBuilder(pgpSec.getPublicKey().getAlgorithm(), digest).setProvider(PROVIDER));
 		sGen.init(PGPSignature.BINARY_DOCUMENT, pgpPrivKey);
 		PGPCompressedDataGenerator comData = new PGPCompressedDataGenerator(PGPCompressedData.ZIP);
-		BCPGOutputStream bOut = new BCPGOutputStream(comData.open(out));
-		int ch;
-		while ((ch = in.read()) >= 0)
+		try (BCPGOutputStream bOut = new BCPGOutputStream(comData.open(out)))
 		{
-			sGen.update((byte)ch);
-		}
-		sGen.generate().encode(bOut);
-		comData.close();
-		if (armor)
-		{
-			out.close();
+			int ch;
+			while ((ch = in.read()) >= 0)
+			{
+				sGen.update((byte)ch);
+			}
+			sGen.generate().encode(bOut);
+			comData.close();
+			if (armor)
+			{
+				out.close();
+			}
 		}
 	}
 

--- a/src/main/java/com/adaptris/security/pgp/PGPVerifyService.java
+++ b/src/main/java/com/adaptris/security/pgp/PGPVerifyService.java
@@ -240,7 +240,7 @@ public class PGPVerifyService extends PGPService
 		PGPSignatureList p3 = (PGPSignatureList)pgpFact.nextObject();
 		PGPSignature sig = p3.get(0);
 		PGPPublicKey publicKey = pgpRings.getPublicKey(sig.getKeyID());
-		sig.init(new JcaPGPContentVerifierBuilderProvider().setProvider("BC"), publicKey);
+		sig.init(new JcaPGPContentVerifierBuilderProvider().setProvider(PROVIDER), publicKey);
 		//
 		// read the input, making sure we ignore the last newline.
 		//
@@ -293,7 +293,7 @@ public class PGPVerifyService extends PGPService
 		PGPPublicKeyRingCollection pgpPubRingCollection = new PGPPublicKeyRingCollection(getDecoderStream(key), new JcaKeyFingerprintCalculator());
 		PGPSignature sig = p3.get(0);
 		PGPPublicKey pubKey = pgpPubRingCollection.getPublicKey(sig.getKeyID());
-		sig.init(new JcaPGPContentVerifierBuilderProvider().setProvider("BC"), pubKey);
+		sig.init(new JcaPGPContentVerifierBuilderProvider().setProvider(PROVIDER), pubKey);
 		int ch;
 		while ((ch = inMessage.read()) >= 0)
 		{

--- a/src/test/java/com/adaptris/security/pgp/PGPEncryptionTests.java
+++ b/src/test/java/com/adaptris/security/pgp/PGPEncryptionTests.java
@@ -153,6 +153,10 @@ public class PGPEncryptionTests extends PGPTests
 			setUp();
 			message.addPayload(PAYLOAD_KEY, getKey(privateKey, false));
 			PGPDecryptService decrypt = getDecryptService(PASSPHRASE, false);
+			MultiPayloadByteArrayInputParameter passParam = new MultiPayloadByteArrayInputParameter();
+			passParam.setPayloadId(PASSPHRASE);
+			message.addPayload(PASSPHRASE, PASSPHRASE.getBytes());
+			decrypt.setPassphrase(passParam);
 			decrypt.doService(message);
 
 			fail();

--- a/src/test/java/com/adaptris/security/pgp/PGPEncryptionTests.java
+++ b/src/test/java/com/adaptris/security/pgp/PGPEncryptionTests.java
@@ -1,7 +1,6 @@
 package com.adaptris.security.pgp;
 
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.common.ConstantDataInputParameter;
 import com.adaptris.core.common.PayloadStreamInputParameter;
 import com.adaptris.core.common.PayloadStreamOutputParameter;
@@ -12,7 +11,9 @@ import org.bouncycastle.openpgp.PGPPublicKey;
 import org.bouncycastle.openpgp.PGPSecretKey;
 import org.junit.Assert;
 import org.junit.Test;
+
 import static org.junit.Assert.fail;
+
 import java.io.ByteArrayOutputStream;
 
 public class PGPEncryptionTests extends PGPTests
@@ -20,12 +21,12 @@ public class PGPEncryptionTests extends PGPTests
 	@Test
 	public void testEntireWorkflow() throws Exception
 	{
-		AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(MESSAGE);
+		AdaptrisMessage message = newMessage();
 		PGPEncryptService encrypt = getEncryptService(publicKey, true, true);
 
 		encrypt.doService(message);
 
-		message = AdaptrisMessageFactory.getDefaultInstance().newMessage(message.getPayload());
+		message = newMessage(message);
 		PGPDecryptService decrypt = getDecryptService(privateKey, PASSPHRASE, true);
 
 		decrypt.doService(message);
@@ -36,12 +37,12 @@ public class PGPEncryptionTests extends PGPTests
 	@Test
 	public void testWorkflowNonArmored() throws Exception
 	{
-		AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(MESSAGE);
+		AdaptrisMessage message = newMessage();
 		PGPEncryptService encrypt = getEncryptService(publicKey, false, true);
 
 		encrypt.doService(message);
 
-		message = AdaptrisMessageFactory.getDefaultInstance().newMessage(message.getPayload());
+		message = newMessage(message);
 		PGPDecryptService decrypt = getDecryptService(privateKey, PASSPHRASE, false);
 
 		decrypt.doService(message);
@@ -52,12 +53,12 @@ public class PGPEncryptionTests extends PGPTests
 	@Test
 	public void testWorkflowNoIntegrity() throws Exception
 	{
-		AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(MESSAGE);
+		AdaptrisMessage message = newMessage();
 		PGPEncryptService encrypt = getEncryptService(publicKey, true, false);
 
 		encrypt.doService(message);
 
-		message = AdaptrisMessageFactory.getDefaultInstance().newMessage(message.getPayload());
+		message = newMessage(message);
 		PGPDecryptService decrypt = getDecryptService(privateKey, PASSPHRASE, true);
 
 		decrypt.doService(message);
@@ -68,12 +69,12 @@ public class PGPEncryptionTests extends PGPTests
 	@Test
 	public void testWorkflowNoArmorOrIntegrity() throws Exception
 	{
-		AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(MESSAGE);
+		AdaptrisMessage message = newMessage();
 		PGPEncryptService encrypt = getEncryptService(publicKey, false, false);
 
 		encrypt.doService(message);
 
-		message = AdaptrisMessageFactory.getDefaultInstance().newMessage(message.getPayload());
+		message = newMessage(message);
 		PGPDecryptService decrypt = getDecryptService(privateKey, PASSPHRASE, false);
 
 		decrypt.doService(message);
@@ -86,7 +87,7 @@ public class PGPEncryptionTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(MESSAGE);
+			AdaptrisMessage message = newMessage();
 			PGPEncryptService service = getEncryptService(publicKey, false, false);
 			service.setPublicKey(new ConstantDataInputParameter());
 			service.doService(message);
@@ -103,7 +104,7 @@ public class PGPEncryptionTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(MESSAGE);
+			AdaptrisMessage message = newMessage();
 			PGPEncryptService service = getEncryptService(publicKey, false, false);
 			service.setClearText(new ConstantDataInputParameter());
 			service.doService(message);
@@ -120,7 +121,7 @@ public class PGPEncryptionTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(MESSAGE);
+			AdaptrisMessage message = newMessage();
 			PGPDecryptService service = getDecryptService(privateKey, PASSPHRASE, false);
 			service.setPrivateKey(new ConstantDataInputParameter());
 			service.doService(message);
@@ -137,12 +138,12 @@ public class PGPEncryptionTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(MESSAGE);
+			AdaptrisMessage message = newMessage();
 			PGPEncryptService encrypt = getEncryptService(publicKey, true, true);
 
 			encrypt.doService(message);
 
-			message = AdaptrisMessageFactory.getDefaultInstance().newMessage(message.getPayload());
+			message = newMessage(message);
 			/* recall setUp to get a new/wrong private key */
 			setUp();
 			PGPDecryptService decrypt = getDecryptService(privateKey, PASSPHRASE, false);
@@ -161,7 +162,7 @@ public class PGPEncryptionTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(MESSAGE);
+			AdaptrisMessage message = newMessage();
 			PGPDecryptService service = getDecryptService(privateKey, PASSPHRASE, false);
 			service.setPassphrase(new ConstantDataInputParameter());
 			service.doService(message);
@@ -178,7 +179,7 @@ public class PGPEncryptionTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(PASSPHRASE);
+			AdaptrisMessage message = newMessage(true);
 			PGPDecryptService service = getDecryptService(privateKey, PASSPHRASE, false);
 			service.setPassphrase(new PayloadStreamInputParameter());
 			service.setCipherText(new ConstantDataInputParameter());
@@ -199,9 +200,11 @@ public class PGPEncryptionTests extends PGPTests
 		armoredKey.close();
 
 		PGPEncryptService service = new PGPEncryptService();
-		service.setPublicKey(new ConstantDataInputParameter(keyBytes.toString()));
+		service.setPublicKey(new ConstantDataInputParameter(keyBytes.toString(ENCODING)));
 		service.setClearText(new StringPayloadDataInputParameter());
-		service.setCipherText(armor ? new StringPayloadDataOutputParameter() : new PayloadStreamOutputParameter());
+		PayloadStreamOutputParameter streamOutput = new PayloadStreamOutputParameter();
+		streamOutput.setContentEncoding(ENCODING);
+		service.setCipherText(armor ? new StringPayloadDataOutputParameter() : streamOutput);
 		service.setArmorEncoding(armor);
 		service.setIntegrityCheck(integrity);
 		return service;
@@ -215,7 +218,7 @@ public class PGPEncryptionTests extends PGPTests
 		armoredKey.close();
 
 		PGPDecryptService service = new PGPDecryptService();
-		service.setPrivateKey(new ConstantDataInputParameter(keyBytes.toString()));
+		service.setPrivateKey(new ConstantDataInputParameter(keyBytes.toString(ENCODING)));
 		service.setPassphrase(new ConstantDataInputParameter(passphrase));
 		service.setCipherText(armor ? new StringPayloadDataInputParameter() : new PayloadStreamInputParameter());
 		service.setClearText(new StringPayloadDataOutputParameter());
@@ -229,7 +232,7 @@ public class PGPEncryptionTests extends PGPTests
 	}
 
     @Override
-    public boolean isAnnotatedForJunit4() 
+    public boolean isAnnotatedForJunit4()
     {
         return true;
     }

--- a/src/test/java/com/adaptris/security/pgp/PGPEncryptionTests.java
+++ b/src/test/java/com/adaptris/security/pgp/PGPEncryptionTests.java
@@ -200,10 +200,9 @@ public class PGPEncryptionTests extends PGPTests
 		armoredKey.close();
 
 		PGPEncryptService service = new PGPEncryptService();
-		service.setPublicKey(new ConstantDataInputParameter(keyBytes.toString(ENCODING)));
+		service.setPublicKey(new ConstantDataInputParameter(keyBytes.toString()));
 		service.setClearText(new StringPayloadDataInputParameter());
 		PayloadStreamOutputParameter streamOutput = new PayloadStreamOutputParameter();
-		streamOutput.setContentEncoding(ENCODING);
 		service.setCipherText(armor ? new StringPayloadDataOutputParameter() : streamOutput);
 		service.setArmorEncoding(armor);
 		service.setIntegrityCheck(integrity);
@@ -218,7 +217,7 @@ public class PGPEncryptionTests extends PGPTests
 		armoredKey.close();
 
 		PGPDecryptService service = new PGPDecryptService();
-		service.setPrivateKey(new ConstantDataInputParameter(keyBytes.toString(ENCODING)));
+		service.setPrivateKey(new ConstantDataInputParameter(keyBytes.toString()));
 		service.setPassphrase(new ConstantDataInputParameter(passphrase));
 		service.setCipherText(armor ? new StringPayloadDataInputParameter() : new PayloadStreamInputParameter());
 		service.setClearText(new StringPayloadDataOutputParameter());

--- a/src/test/java/com/adaptris/security/pgp/PGPEncryptionTests.java
+++ b/src/test/java/com/adaptris/security/pgp/PGPEncryptionTests.java
@@ -1,11 +1,10 @@
 package com.adaptris.security.pgp;
 
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.common.ConstantDataInputParameter;
-import com.adaptris.core.common.PayloadStreamInputParameter;
-import com.adaptris.core.common.PayloadStreamOutputParameter;
-import com.adaptris.core.common.StringPayloadDataInputParameter;
-import com.adaptris.core.common.StringPayloadDataOutputParameter;
+import com.adaptris.core.MultiPayloadAdaptrisMessage;
+import com.adaptris.core.common.*;
+import com.adaptris.interlok.config.DataInputParameter;
+import com.adaptris.interlok.config.DataOutputParameter;
 import org.bouncycastle.bcpg.ArmoredOutputStream;
 import org.bouncycastle.openpgp.PGPPublicKey;
 import org.bouncycastle.openpgp.PGPSecretKey;
@@ -21,65 +20,65 @@ public class PGPEncryptionTests extends PGPTests
 	@Test
 	public void testEntireWorkflow() throws Exception
 	{
-		AdaptrisMessage message = newMessage();
-		PGPEncryptService encrypt = getEncryptService(publicKey, true, true);
-
+		MultiPayloadAdaptrisMessage message = newMessage();
+		message.addPayload(PAYLOAD_KEY, getKey(publicKey, true));
+		PGPEncryptService encrypt = getEncryptService(true, true);
 		encrypt.doService(message);
 
 		message = newMessage(message);
-		PGPDecryptService decrypt = getDecryptService(privateKey, PASSPHRASE, true);
-
+		message.addPayload(PAYLOAD_KEY, getKey(privateKey, true));
+		PGPDecryptService decrypt = getDecryptService(PASSPHRASE, true);
 		decrypt.doService(message);
 
-		Assert.assertEquals(MESSAGE, message.getContent());
+		Assert.assertEquals(MESSAGE, message.getContent(PAYLOAD_PLAINTEXT));
 	}
 
 	@Test
 	public void testWorkflowNonArmored() throws Exception
 	{
-		AdaptrisMessage message = newMessage();
-		PGPEncryptService encrypt = getEncryptService(publicKey, false, true);
-
+		MultiPayloadAdaptrisMessage message = newMessage();
+		message.addPayload(PAYLOAD_KEY, getKey(publicKey, false));
+		PGPEncryptService encrypt = getEncryptService(false, true);
 		encrypt.doService(message);
 
 		message = newMessage(message);
-		PGPDecryptService decrypt = getDecryptService(privateKey, PASSPHRASE, false);
-
+		message.addPayload(PAYLOAD_KEY, getKey(privateKey, false));
+		PGPDecryptService decrypt = getDecryptService(PASSPHRASE, false);
 		decrypt.doService(message);
 
-		Assert.assertEquals(MESSAGE, message.getContent());
+		Assert.assertEquals(MESSAGE, message.getContent(PAYLOAD_PLAINTEXT));
 	}
 
 	@Test
 	public void testWorkflowNoIntegrity() throws Exception
 	{
-		AdaptrisMessage message = newMessage();
-		PGPEncryptService encrypt = getEncryptService(publicKey, true, false);
-
+		MultiPayloadAdaptrisMessage message = newMessage();
+		message.addPayload(PAYLOAD_KEY, getKey(publicKey, true));
+		PGPEncryptService encrypt = getEncryptService(true, false);
 		encrypt.doService(message);
 
 		message = newMessage(message);
-		PGPDecryptService decrypt = getDecryptService(privateKey, PASSPHRASE, true);
-
+		message.addPayload(PAYLOAD_KEY, getKey(privateKey, true));
+		PGPDecryptService decrypt = getDecryptService(PASSPHRASE, true);
 		decrypt.doService(message);
 
-		Assert.assertEquals(MESSAGE, message.getContent());
+		Assert.assertEquals(MESSAGE, message.getContent(PAYLOAD_PLAINTEXT));
 	}
 
 	@Test
 	public void testWorkflowNoArmorOrIntegrity() throws Exception
 	{
-		AdaptrisMessage message = newMessage();
-		PGPEncryptService encrypt = getEncryptService(publicKey, false, false);
-
+		MultiPayloadAdaptrisMessage message = newMessage();
+		message.addPayload(PAYLOAD_KEY, getKey(publicKey, false));
+		PGPEncryptService encrypt = getEncryptService(false, false);
 		encrypt.doService(message);
 
 		message = newMessage(message);
-		PGPDecryptService decrypt = getDecryptService(privateKey, PASSPHRASE, false);
-
+		message.addPayload(PAYLOAD_KEY, getKey(privateKey, false));
+		PGPDecryptService decrypt = getDecryptService(PASSPHRASE, false);
 		decrypt.doService(message);
 
-		Assert.assertEquals(MESSAGE, message.getContent());
+		Assert.assertEquals(MESSAGE, message.getContent(PAYLOAD_PLAINTEXT));
 	}
 
 	@Test
@@ -87,10 +86,12 @@ public class PGPEncryptionTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = newMessage();
-			PGPEncryptService service = getEncryptService(publicKey, false, false);
+			MultiPayloadAdaptrisMessage message = newMessage();
+			message.addPayload(PAYLOAD_KEY, getKey(publicKey, false));
+			PGPEncryptService service = getEncryptService(false, false);
 			service.setPublicKey(new ConstantDataInputParameter());
 			service.doService(message);
+
 			fail();
 		}
 		catch (Exception e)
@@ -104,10 +105,12 @@ public class PGPEncryptionTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = newMessage();
-			PGPEncryptService service = getEncryptService(publicKey, false, false);
+			MultiPayloadAdaptrisMessage message = newMessage();
+			message.addPayload(PAYLOAD_KEY, getKey(publicKey, false));
+			PGPEncryptService service = getEncryptService(false, false);
 			service.setClearText(new ConstantDataInputParameter());
 			service.doService(message);
+
 			fail();
 		}
 		catch (Exception e)
@@ -121,10 +124,12 @@ public class PGPEncryptionTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = newMessage();
-			PGPDecryptService service = getDecryptService(privateKey, PASSPHRASE, false);
+			MultiPayloadAdaptrisMessage message = newMessage();
+			message.addPayload(PAYLOAD_KEY, getKey(privateKey, false));
+			PGPDecryptService service = getDecryptService(PASSPHRASE, false);
 			service.setPrivateKey(new ConstantDataInputParameter());
 			service.doService(message);
+
 			fail();
 		}
 		catch (Exception e)
@@ -138,17 +143,18 @@ public class PGPEncryptionTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = newMessage();
-			PGPEncryptService encrypt = getEncryptService(publicKey, true, true);
-
+			MultiPayloadAdaptrisMessage message = newMessage();
+			message.addPayload(PAYLOAD_KEY, getKey(publicKey, true));
+			PGPEncryptService encrypt = getEncryptService(true, true);
 			encrypt.doService(message);
 
 			message = newMessage(message);
 			/* recall setUp to get a new/wrong private key */
 			setUp();
-			PGPDecryptService decrypt = getDecryptService(privateKey, PASSPHRASE, false);
-
+			message.addPayload(PAYLOAD_KEY, getKey(privateKey, false));
+			PGPDecryptService decrypt = getDecryptService(PASSPHRASE, false);
 			decrypt.doService(message);
+
 			fail();
 		}
 		catch (Exception e)
@@ -162,10 +168,12 @@ public class PGPEncryptionTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = newMessage();
-			PGPDecryptService service = getDecryptService(privateKey, PASSPHRASE, false);
+			MultiPayloadAdaptrisMessage message = newMessage();
+			message.addPayload(PAYLOAD_KEY, getKey(privateKey, false));
+			PGPDecryptService service = getDecryptService(PASSPHRASE, false);
 			service.setPassphrase(new ConstantDataInputParameter());
 			service.doService(message);
+
 			fail();
 		}
 		catch (Exception e)
@@ -179,11 +187,13 @@ public class PGPEncryptionTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = newMessage(true);
-			PGPDecryptService service = getDecryptService(privateKey, PASSPHRASE, false);
+			MultiPayloadAdaptrisMessage message = newMessage(true);
+			message.addPayload(PAYLOAD_KEY, getKey(privateKey, false));
+			PGPDecryptService service = getDecryptService(PASSPHRASE, false);
 			service.setPassphrase(new PayloadStreamInputParameter());
 			service.setCipherText(new ConstantDataInputParameter());
 			service.doService(message);
+
 			fail();
 		}
 		catch (Exception e)
@@ -192,35 +202,28 @@ public class PGPEncryptionTests extends PGPTests
 		}
 	}
 
-	private PGPEncryptService getEncryptService(PGPPublicKey key, boolean armor, boolean integrity) throws Exception
+	private PGPEncryptService getEncryptService(boolean armor, boolean integrity) throws Exception
 	{
-		ByteArrayOutputStream keyBytes = new ByteArrayOutputStream();
-		ArmoredOutputStream armoredKey = new ArmoredOutputStream(keyBytes);
-		key.encode(armoredKey);
-		armoredKey.close();
-
 		PGPEncryptService service = new PGPEncryptService();
-		service.setPublicKey(new ConstantDataInputParameter(keyBytes.toString()));
-		service.setClearText(new StringPayloadDataInputParameter());
-		PayloadStreamOutputParameter streamOutput = new PayloadStreamOutputParameter();
-		service.setCipherText(armor ? new StringPayloadDataOutputParameter() : streamOutput);
+		service.setPublicKey(getKeyInput(armor));
+		MultiPayloadStringInputParameter clearParam = new MultiPayloadStringInputParameter();
+		clearParam.setPayloadId(PAYLOAD_PLAINTEXT);
+		service.setClearText(clearParam);
+		service.setCipherText(getCipherOutput(armor));
 		service.setArmorEncoding(armor);
 		service.setIntegrityCheck(integrity);
 		return service;
 	}
 
-	private PGPDecryptService getDecryptService(PGPSecretKey key, String passphrase, boolean armor) throws Exception
+	private PGPDecryptService getDecryptService(String passphrase, boolean armor) throws Exception
 	{
-		ByteArrayOutputStream keyBytes = new ByteArrayOutputStream();
-		ArmoredOutputStream armoredKey = new ArmoredOutputStream(keyBytes);
-		key.encode(armoredKey);
-		armoredKey.close();
-
 		PGPDecryptService service = new PGPDecryptService();
-		service.setPrivateKey(new ConstantDataInputParameter(keyBytes.toString()));
+		service.setPrivateKey(getKeyInput(armor));
 		service.setPassphrase(new ConstantDataInputParameter(passphrase));
-		service.setCipherText(armor ? new StringPayloadDataInputParameter() : new PayloadStreamInputParameter());
-		service.setClearText(new StringPayloadDataOutputParameter());
+		service.setCipherText(getCipherInput(armor));
+		MultiPayloadStringOutputParameter plainParam = new MultiPayloadStringOutputParameter();
+		plainParam.setPayloadId(PAYLOAD_PLAINTEXT);
+		service.setClearText(plainParam);
 		return service;
 	}
 

--- a/src/test/java/com/adaptris/security/pgp/PGPSignatureTests.java
+++ b/src/test/java/com/adaptris/security/pgp/PGPSignatureTests.java
@@ -1,12 +1,10 @@
 package com.adaptris.security.pgp;
 
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.common.ConstantDataInputParameter;
-import com.adaptris.core.common.MetadataDataInputParameter;
-import com.adaptris.core.common.PayloadStreamInputParameter;
-import com.adaptris.core.common.PayloadStreamOutputParameter;
-import com.adaptris.core.common.StringPayloadDataInputParameter;
-import com.adaptris.core.common.StringPayloadDataOutputParameter;
+import com.adaptris.core.MultiPayloadAdaptrisMessage;
+import com.adaptris.core.common.*;
+import com.adaptris.interlok.config.DataInputParameter;
+import com.adaptris.interlok.config.DataOutputParameter;
 import org.bouncycastle.openpgp.PGPPublicKey;
 import org.bouncycastle.openpgp.PGPSecretKey;
 import org.junit.Assert;
@@ -19,51 +17,51 @@ public class PGPSignatureTests extends PGPTests
 	@Test
 	public void testSignatureDetached() throws Exception
 	{
-		AdaptrisMessage message = newMessage();
-		PGPSignService sign = getSignService(privateKey, PASSPHRASE, true, true);
-
+		MultiPayloadAdaptrisMessage message = newMessage();
+		message.addPayload(PAYLOAD_KEY, getKey(privateKey, true));
+		PGPSignService sign = getSignService(PASSPHRASE, true, true);
 		sign.doService(message);
 
 		message = newMessage(message);
-		message.addMetadata("message", MESSAGE);
-		PGPVerifyService verify = getVerifyService(publicKey, true);
-
+		message.addContent(PAYLOAD_PLAINTEXT, MESSAGE);
+		message.addPayload(PAYLOAD_KEY, getKey(publicKey, true));
+		PGPVerifyService verify = getVerifyService(true, true);
 		verify.doService(message);
 
-		Assert.assertEquals(MESSAGE, message.getContent());
+		Assert.assertEquals(MESSAGE, message.getContent(PAYLOAD_PLAINTEXT));
 	}
 
 	@Test
 	public void testSignatureDetachedNoArmor() throws Exception
 	{
-		AdaptrisMessage message = newMessage();
-		PGPSignService sign = getSignService(privateKey, PASSPHRASE, true, false);
-
+		MultiPayloadAdaptrisMessage message = newMessage();
+		message.addPayload(PAYLOAD_KEY, getKey(privateKey, false));
+		PGPSignService sign = getSignService(PASSPHRASE, true, false);
 		sign.doService(message);
 
 		message = newMessage(message);
-		message.addMetadata("message", MESSAGE);
-		PGPVerifyService verify = getVerifyService(publicKey, true);
-
+		message.addContent(PAYLOAD_PLAINTEXT, MESSAGE);
+		message.addPayload(PAYLOAD_KEY, getKey(publicKey, false));
+		PGPVerifyService verify = getVerifyService(true, false);
 		verify.doService(message);
 
-		Assert.assertEquals(MESSAGE, message.getContent());
+		Assert.assertEquals(MESSAGE, message.getContent(PAYLOAD_PLAINTEXT));
 	}
 
 	@Test
 	public void testSignatureClear() throws Exception
 	{
-		AdaptrisMessage message = newMessage();
-		PGPSignService sign = getSignService(privateKey, PASSPHRASE, false, true);
-
+		MultiPayloadAdaptrisMessage message = newMessage();
+		message.addPayload(PAYLOAD_KEY, getKey(privateKey, true));
+		PGPSignService sign = getSignService(PASSPHRASE, false, true);
 		sign.doService(message);
 
 		message = newMessage(message);
-		PGPVerifyService verify = getVerifyService(publicKey, false);
-
+		message.addPayload(PAYLOAD_KEY, getKey(publicKey, true));
+		PGPVerifyService verify = getVerifyService(false, true);
 		verify.doService(message);
 
-		Assert.assertEquals(MESSAGE, message.getContent());
+		Assert.assertEquals(MESSAGE, message.getContent(PAYLOAD_PLAINTEXT));
 	}
 
 	@Test
@@ -71,10 +69,12 @@ public class PGPSignatureTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = newMessage();
-			PGPSignService service = getSignService(privateKey, PASSPHRASE, true, true);
+			MultiPayloadAdaptrisMessage message = newMessage();
+			message.addPayload(PAYLOAD_KEY, getKey(privateKey, true));
+			PGPSignService service = getSignService(PASSPHRASE, true, true);
 			service.setPrivateKey(new ConstantDataInputParameter());
 			service.doService(message);
+
 			fail();
 		}
 		catch (Exception e)
@@ -88,10 +88,12 @@ public class PGPSignatureTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = newMessage();
-			PGPSignService service = getSignService(privateKey, PASSPHRASE, true, true);
+			MultiPayloadAdaptrisMessage message = newMessage();
+			message.addPayload(PAYLOAD_KEY, getKey(privateKey, true));
+			PGPSignService service = getSignService(PASSPHRASE, true, true);
 			service.setPassphrase(new ConstantDataInputParameter());
 			service.doService(message);
+
 			fail();
 		}
 		catch (Exception e)
@@ -105,11 +107,13 @@ public class PGPSignatureTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = newMessage(true);
-			PGPSignService service = getSignService(privateKey, PASSPHRASE, true, true);
+			MultiPayloadAdaptrisMessage message = newMessage(true);
+			message.addPayload(PAYLOAD_KEY, getKey(privateKey, true));
+			PGPSignService service = getSignService(PASSPHRASE, true, true);
 			service.setPassphrase(new PayloadStreamInputParameter());
 			service.setClearText(new ConstantDataInputParameter());
 			service.doService(message);
+
 			fail();
 		}
 		catch (Exception e)
@@ -123,10 +127,12 @@ public class PGPSignatureTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = newMessage();
-			PGPVerifyService service = getVerifyService(publicKey, false);
+			MultiPayloadAdaptrisMessage message = newMessage();
+			message.addPayload(PAYLOAD_KEY, getKey(publicKey, true));
+			PGPVerifyService service = getVerifyService(false, true);
 			service.setPublicKey(new ConstantDataInputParameter());
 			service.doService(message);
+
 			fail();
 		}
 		catch (Exception e)
@@ -140,10 +146,12 @@ public class PGPSignatureTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = newMessage();
-			PGPVerifyService service = getVerifyService(publicKey, false);
+			MultiPayloadAdaptrisMessage message = newMessage();
+			message.addPayload(PAYLOAD_KEY, getKey(publicKey, true));
+			PGPVerifyService service = getVerifyService(false, true);
 			service.setSignedMessage(new ConstantDataInputParameter());
 			service.doService(message);
+
 			fail();
 		}
 		catch (Exception e)
@@ -157,10 +165,12 @@ public class PGPSignatureTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = newMessage();
-			PGPVerifyService service = getVerifyService(publicKey, false);
+			MultiPayloadAdaptrisMessage message = newMessage();
+			message.addPayload(PAYLOAD_KEY, getKey(publicKey, true));
+			PGPVerifyService service = getVerifyService(false, true);
 			service.setSignature(new ConstantDataInputParameter());
 			service.doService(message);
+
 			fail();
 		}
 		catch (Exception e)
@@ -174,10 +184,12 @@ public class PGPSignatureTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = newMessage();
-			PGPVerifyService service = getVerifyService(publicKey, false);
+			MultiPayloadAdaptrisMessage message = newMessage();
+			message.addPayload(PAYLOAD_KEY, getKey(publicKey, true));
+			PGPVerifyService service = getVerifyService(false, true);
 			service.setSignature(new ConstantDataInputParameter(""));
 			service.doService(message);
+
 			fail();
 		}
 		catch (Exception e)
@@ -191,15 +203,15 @@ public class PGPSignatureTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = newMessage();
-			PGPSignService sign = getSignService(privateKey, PASSPHRASE, true, true);
-
+			MultiPayloadAdaptrisMessage message = newMessage();
+			message.addPayload(PAYLOAD_KEY, getKey(privateKey, true));
+			PGPSignService sign = getSignService(PASSPHRASE, true, true);
 			sign.doService(message);
 
 			message = newMessage(message);
 			message.addMetadata("message", MESSAGE.replace('g', 'z'));
-			PGPVerifyService verify = getVerifyService(publicKey, true);
-
+			message.addPayload(PAYLOAD_KEY, getKey(publicKey, true));
+			PGPVerifyService verify = getVerifyService(true, true);
 			verify.doService(message);
 
 			fail();
@@ -215,19 +227,18 @@ public class PGPSignatureTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = newMessage();
-			PGPSignService sign = getSignService(privateKey, PASSPHRASE, false, true);
-
+			MultiPayloadAdaptrisMessage message = newMessage();
+			message.addPayload(PAYLOAD_KEY, getKey(privateKey, true));
+			PGPSignService sign = getSignService(PASSPHRASE, false, true);
 			sign.doService(message);
 
-			byte[] corruptMessage = message.getPayload();
+			byte[] corruptMessage = message.getPayload(PAYLOAD_CIPHERTEXT);
 			/* corrupt the message payload to force an error */
 			corruptMessage[corruptMessage.length / 2] += 1;
-			message.setPayload(corruptMessage);
-
 			message = newMessage(message);
-			PGPVerifyService verify = getVerifyService(publicKey, false);
-
+			message.addPayload(PAYLOAD_CIPHERTEXT, corruptMessage);
+			message.addPayload(PAYLOAD_KEY, getKey(publicKey, true));
+			PGPVerifyService verify = getVerifyService(false, true);
 			verify.doService(message);
 
 			fail();
@@ -238,25 +249,53 @@ public class PGPSignatureTests extends PGPTests
 		}
 	}
 
-	private PGPSignService getSignService(PGPSecretKey key, String passphrase, boolean detached, boolean armor) throws Exception
+	private PGPSignService getSignService(String passphrase, boolean detached, boolean armor) throws Exception
 	{
 		PGPSignService service = new PGPSignService();
-		service.setPrivateKey(new ConstantDataInputParameter(getKey(key)));
+		service.setPrivateKey(getKeyInput(armor));
 		service.setPassphrase(new ConstantDataInputParameter(passphrase));
-		service.setClearText(detached ? new StringPayloadDataInputParameter() : new PayloadStreamInputParameter());
+		DataInputParameter plainParam;
+		if (detached)
+		{
+			plainParam = new MultiPayloadStringInputParameter();
+			((MultiPayloadStringInputParameter)plainParam).setPayloadId(PAYLOAD_PLAINTEXT);
+		}
+		else
+		{
+			plainParam = new MultiPayloadStreamInputParameter();
+			((MultiPayloadStreamInputParameter)plainParam).setPayloadId(PAYLOAD_PLAINTEXT);
+		}
+		service.setClearText(plainParam);
 		service.setDetachedSignature(detached);
 		service.setArmorEncoding(armor);
-		service.setSignature(detached ? new PayloadStreamOutputParameter() : new StringPayloadDataOutputParameter());
+		service.setSignature(getCipherOutput(armor));
 		return service;
 	}
 
-	private PGPVerifyService getVerifyService(PGPPublicKey key, boolean detached) throws Exception
+	private PGPVerifyService getVerifyService(boolean detached, boolean armor) throws Exception
 	{
 		PGPVerifyService service = new PGPVerifyService();
-		service.setPublicKey(new ConstantDataInputParameter(getKey(key)));
-		service.setSignedMessage(detached ? new MetadataDataInputParameter("message") : new PayloadStreamInputParameter());
-		service.setSignature(detached ? new PayloadStreamInputParameter() : null);
-		service.setOriginalMessage(detached ? new StringPayloadDataOutputParameter() : new PayloadStreamOutputParameter());
+		service.setPublicKey(getKeyInput(armor));
+		MultiPayloadStreamInputParameter originalMessageParam = null;
+		if (detached)
+		{
+			originalMessageParam = new MultiPayloadStreamInputParameter();
+			originalMessageParam.setPayloadId(PAYLOAD_PLAINTEXT);
+		}
+		service.setSignedMessage(detached ? originalMessageParam : getCipherInput(false));
+		service.setSignature(detached ? getCipherInput(armor) : null);
+		DataOutputParameter plainParam;
+		if (detached)
+		{
+			plainParam = new MultiPayloadStringOutputParameter();
+			((MultiPayloadStringOutputParameter)plainParam).setPayloadId(PAYLOAD_PLAINTEXT);
+		}
+		else
+		{
+			plainParam = new MultiPayloadStreamOutputParameter();
+			((MultiPayloadStreamOutputParameter)plainParam).setPayloadId(PAYLOAD_PLAINTEXT);
+		}
+		service.setOriginalMessage(plainParam);
 		return service;
 	}
 

--- a/src/test/java/com/adaptris/security/pgp/PGPSignatureTests.java
+++ b/src/test/java/com/adaptris/security/pgp/PGPSignatureTests.java
@@ -1,30 +1,30 @@
 package com.adaptris.security.pgp;
 
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.common.ConstantDataInputParameter;
 import com.adaptris.core.common.MetadataDataInputParameter;
 import com.adaptris.core.common.PayloadStreamInputParameter;
 import com.adaptris.core.common.PayloadStreamOutputParameter;
 import com.adaptris.core.common.StringPayloadDataInputParameter;
 import com.adaptris.core.common.StringPayloadDataOutputParameter;
-import static org.junit.Assert.fail;
 import org.bouncycastle.openpgp.PGPPublicKey;
 import org.bouncycastle.openpgp.PGPSecretKey;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.fail;
 
 public class PGPSignatureTests extends PGPTests
 {
 	@Test
 	public void testSignatureDetached() throws Exception
 	{
-		AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(MESSAGE);
+		AdaptrisMessage message = newMessage();
 		PGPSignService sign = getSignService(privateKey, PASSPHRASE, true, true);
 
 		sign.doService(message);
 
-		message = AdaptrisMessageFactory.getDefaultInstance().newMessage(message.getContent());
+		message = newMessage(message);
 		message.addMetadata("message", MESSAGE);
 		PGPVerifyService verify = getVerifyService(publicKey, true);
 
@@ -36,12 +36,12 @@ public class PGPSignatureTests extends PGPTests
 	@Test
 	public void testSignatureDetachedNoArmor() throws Exception
 	{
-		AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(MESSAGE);
+		AdaptrisMessage message = newMessage();
 		PGPSignService sign = getSignService(privateKey, PASSPHRASE, true, false);
 
 		sign.doService(message);
 
-		message = AdaptrisMessageFactory.getDefaultInstance().newMessage(message.getPayload());
+		message = newMessage(message);
 		message.addMetadata("message", MESSAGE);
 		PGPVerifyService verify = getVerifyService(publicKey, true);
 
@@ -53,12 +53,12 @@ public class PGPSignatureTests extends PGPTests
 	@Test
 	public void testSignatureClear() throws Exception
 	{
-		AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(MESSAGE);
+		AdaptrisMessage message = newMessage();
 		PGPSignService sign = getSignService(privateKey, PASSPHRASE, false, true);
 
 		sign.doService(message);
 
-		message = AdaptrisMessageFactory.getDefaultInstance().newMessage(message.getPayload());
+		message = newMessage(message);
 		PGPVerifyService verify = getVerifyService(publicKey, false);
 
 		verify.doService(message);
@@ -71,7 +71,7 @@ public class PGPSignatureTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(MESSAGE);
+			AdaptrisMessage message = newMessage();
 			PGPSignService service = getSignService(privateKey, PASSPHRASE, true, true);
 			service.setPrivateKey(new ConstantDataInputParameter());
 			service.doService(message);
@@ -88,7 +88,7 @@ public class PGPSignatureTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(MESSAGE);
+			AdaptrisMessage message = newMessage();
 			PGPSignService service = getSignService(privateKey, PASSPHRASE, true, true);
 			service.setPassphrase(new ConstantDataInputParameter());
 			service.doService(message);
@@ -105,7 +105,7 @@ public class PGPSignatureTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(PASSPHRASE);
+			AdaptrisMessage message = newMessage(true);
 			PGPSignService service = getSignService(privateKey, PASSPHRASE, true, true);
 			service.setPassphrase(new PayloadStreamInputParameter());
 			service.setClearText(new ConstantDataInputParameter());
@@ -123,7 +123,7 @@ public class PGPSignatureTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(MESSAGE);
+			AdaptrisMessage message = newMessage();
 			PGPVerifyService service = getVerifyService(publicKey, false);
 			service.setPublicKey(new ConstantDataInputParameter());
 			service.doService(message);
@@ -140,7 +140,7 @@ public class PGPSignatureTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(MESSAGE);
+			AdaptrisMessage message = newMessage();
 			PGPVerifyService service = getVerifyService(publicKey, false);
 			service.setSignedMessage(new ConstantDataInputParameter());
 			service.doService(message);
@@ -157,7 +157,7 @@ public class PGPSignatureTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(MESSAGE);
+			AdaptrisMessage message = newMessage();
 			PGPVerifyService service = getVerifyService(publicKey, false);
 			service.setSignature(new ConstantDataInputParameter());
 			service.doService(message);
@@ -174,7 +174,7 @@ public class PGPSignatureTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(MESSAGE);
+			AdaptrisMessage message = newMessage();
 			PGPVerifyService service = getVerifyService(publicKey, false);
 			service.setSignature(new ConstantDataInputParameter(""));
 			service.doService(message);
@@ -191,12 +191,12 @@ public class PGPSignatureTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(MESSAGE);
+			AdaptrisMessage message = newMessage();
 			PGPSignService sign = getSignService(privateKey, PASSPHRASE, true, true);
 
 			sign.doService(message);
 
-			message = AdaptrisMessageFactory.getDefaultInstance().newMessage(message.getPayload());
+			message = newMessage(message);
 			message.addMetadata("message", MESSAGE.replace('g', 'z'));
 			PGPVerifyService verify = getVerifyService(publicKey, true);
 
@@ -215,15 +215,17 @@ public class PGPSignatureTests extends PGPTests
 	{
 		try
 		{
-			AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(MESSAGE);
+			AdaptrisMessage message = newMessage();
 			PGPSignService sign = getSignService(privateKey, PASSPHRASE, false, true);
 
 			sign.doService(message);
 
-			byte[] signedMessage = message.getPayload();
-			signedMessage[signedMessage.length / 2] += 1;
+			byte[] corruptMessage = message.getPayload();
+			/* corrupt the message payload to force an error */
+			corruptMessage[corruptMessage.length / 2] += 1;
+			message.setPayload(corruptMessage);
 
-			message = AdaptrisMessageFactory.getDefaultInstance().newMessage(signedMessage);
+			message = newMessage(message);
 			PGPVerifyService verify = getVerifyService(publicKey, false);
 
 			verify.doService(message);
@@ -265,7 +267,7 @@ public class PGPSignatureTests extends PGPTests
 	}
 
     @Override
-    public boolean isAnnotatedForJunit4() 
+    public boolean isAnnotatedForJunit4()
     {
         return true;
     }

--- a/src/test/java/com/adaptris/security/pgp/PGPTests.java
+++ b/src/test/java/com/adaptris/security/pgp/PGPTests.java
@@ -6,6 +6,7 @@ import com.adaptris.core.MultiPayloadAdaptrisMessage;
 import com.adaptris.core.MultiPayloadMessageFactory;
 import com.adaptris.core.ServiceCase;
 import com.adaptris.core.common.MultiPayloadByteArrayInputParameter;
+import com.adaptris.core.common.MultiPayloadByteArrayOutputParameter;
 import com.adaptris.core.common.MultiPayloadStreamInputParameter;
 import com.adaptris.core.common.MultiPayloadStreamOutputParameter;
 import com.adaptris.core.common.MultiPayloadStringInputParameter;
@@ -256,8 +257,8 @@ abstract class PGPTests extends ServiceCase
 		}
 		else
 		{
-			cipherParam = new MultiPayloadStreamOutputParameter();
-			((MultiPayloadStreamOutputParameter)cipherParam).setPayloadId(PAYLOAD_CIPHERTEXT);
+			cipherParam = new MultiPayloadByteArrayOutputParameter();
+			((MultiPayloadByteArrayOutputParameter)cipherParam).setPayloadId(PAYLOAD_CIPHERTEXT);
 		}
 		return cipherParam;
 	}

--- a/src/test/java/com/adaptris/security/pgp/PGPTests.java
+++ b/src/test/java/com/adaptris/security/pgp/PGPTests.java
@@ -27,7 +27,6 @@ import java.util.Date;
 abstract class PGPTests extends ServiceCase
 {
 	protected static final String MESSAGE = "Spicy jalapeno bacon ipsum dolor amet shankle hamburger tri-tip, filet mignon ham sirloin prosciutto pig andouille pork belly pork loin. Tail beef kielbasa alcatra salami doner turkey corned beef fatback leberkas pastrami shoulder spare ribs filet mignon pork loin. Cupim doner pastrami chicken venison pork loin. Ribeye pork tri-tip cow buffalo rump boudin sirloin short ribs picanha salami." + System.getProperty("line.separator");
-	protected static final String ENCODING = "UTF-8";
 	protected static final String ID = "email@example.com";
 	protected static final String PASSPHRASE = "passphrase";
 
@@ -108,7 +107,7 @@ abstract class PGPTests extends ServiceCase
 	 */
 	protected AdaptrisMessage newMessage(boolean passphrase) throws Exception
 	{
-		return AdaptrisMessageFactory.getDefaultInstance().newMessage(passphrase ? PASSPHRASE : MESSAGE, ENCODING);
+		return AdaptrisMessageFactory.getDefaultInstance().newMessage(passphrase ? PASSPHRASE : MESSAGE);
 	}
 
 	/**
@@ -142,7 +141,7 @@ abstract class PGPTests extends ServiceCase
 		ArmoredOutputStream armored = new ArmoredOutputStream(keyBytes);
 		key.encode(armored);
 		armored.close();
-		return keyBytes.toString(ENCODING);
+		return keyBytes.toString();
 	}
 
 	/**
@@ -160,6 +159,6 @@ abstract class PGPTests extends ServiceCase
 		ArmoredOutputStream armored = new ArmoredOutputStream(keyBytes);
 		key.encode(armored);
 		armored.close();
-		return keyBytes.toString(ENCODING);
+		return keyBytes.toString();
 	}
 }

--- a/src/test/java/com/adaptris/security/pgp/PGPTests.java
+++ b/src/test/java/com/adaptris/security/pgp/PGPTests.java
@@ -1,5 +1,7 @@
 package com.adaptris.security.pgp;
 
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ServiceCase;
 import org.bouncycastle.bcpg.ArmoredOutputStream;
 import org.bouncycastle.bcpg.HashAlgorithmTags;
@@ -25,6 +27,7 @@ import java.util.Date;
 abstract class PGPTests extends ServiceCase
 {
 	protected static final String MESSAGE = "Spicy jalapeno bacon ipsum dolor amet shankle hamburger tri-tip, filet mignon ham sirloin prosciutto pig andouille pork belly pork loin. Tail beef kielbasa alcatra salami doner turkey corned beef fatback leberkas pastrami shoulder spare ribs filet mignon pork loin. Cupim doner pastrami chicken venison pork loin. Ribeye pork tri-tip cow buffalo rump boudin sirloin short ribs picanha salami." + System.getProperty("line.separator");
+	protected static final String ENCODING = "UTF-8";
 	protected static final String ID = "email@example.com";
 	protected static final String PASSPHRASE = "passphrase";
 
@@ -35,30 +38,128 @@ abstract class PGPTests extends ServiceCase
 	public void setUp() throws Exception
 	{
 		Security.addProvider(new BouncyCastleProvider());
-		KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", "BC");
+		KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", PGPService.PROVIDER);
 		kpg.initialize(1024);
 		KeyPair kp = kpg.generateKeyPair();
 		PGPDigestCalculator sha1Calc = new JcaPGPDigestCalculatorProviderBuilder().build().get(HashAlgorithmTags.SHA1);
 		PGPKeyPair keyPair = new JcaPGPKeyPair(PGPPublicKey.RSA_GENERAL, kp, new Date());
-		privateKey = new PGPSecretKey(PGPSignature.DEFAULT_CERTIFICATION, keyPair, ID, sha1Calc, null, null, new JcaPGPContentSignerBuilder(keyPair.getPublicKey().getAlgorithm(), HashAlgorithmTags.SHA1), new JcePBESecretKeyEncryptorBuilder(PGPEncryptedData.AES_256, sha1Calc).setProvider("BC").build(PASSPHRASE.toCharArray()));
+		privateKey = new PGPSecretKey(PGPSignature.DEFAULT_CERTIFICATION, keyPair, ID, sha1Calc, null, null, new JcaPGPContentSignerBuilder(keyPair.getPublicKey().getAlgorithm(), HashAlgorithmTags.SHA1), new JcePBESecretKeyEncryptorBuilder(PGPEncryptedData.AES_256, sha1Calc).setProvider(PGPService.PROVIDER).build(PASSPHRASE.toCharArray()));
 		publicKey = privateKey.getPublicKey();
+		/*
+		try (InputStream i = new FileInputStream("C:\\adaptris\\testkey.asc"))
+		{
+			PGPSecretKeyRingCollection pgpSec = new PGPSecretKeyRingCollection(PGPUtil.getDecoderStream(i), new JcaKeyFingerprintCalculator());
+			Iterator keyRingIter = pgpSec.getKeyRings();
+			while (keyRingIter.hasNext() && privateKey == null)
+			{
+				PGPSecretKeyRing keyRing = (PGPSecretKeyRing)keyRingIter.next();
+				Iterator keyIter = keyRing.getSecretKeys();
+				while (keyIter.hasNext() && privateKey == null)
+				{
+					PGPSecretKey key = (PGPSecretKey)keyIter.next();
+					if (key.isSigningKey())
+					{
+						privateKey = key;
+					}
+				}
+			}
+		}
+		try (InputStream i = new FileInputStream("C:\\adaptris\\testkey.asc.pub"))
+		{
+			PGPPublicKeyRingCollection pgpPub = new PGPPublicKeyRingCollection(PGPUtil.getDecoderStream(i), new JcaKeyFingerprintCalculator());
+			Iterator keyRingIter = pgpPub.getKeyRings();
+			while (keyRingIter.hasNext() && publicKey == null)
+			{
+				PGPPublicKeyRing keyRing = (PGPPublicKeyRing)keyRingIter.next();
+				Iterator keyIter = keyRing.getPublicKeys();
+				while (keyIter.hasNext() && publicKey == null)
+				{
+					PGPPublicKey key = (PGPPublicKey)keyIter.next();
+					if (key.isEncryptionKey())
+					{
+						publicKey = key;
+					}
+				}
+			}
+		}
+		*/
 	}
 
+	/**
+	 * Create a new message with a known default payload.
+	 *
+	 * @return A new message
+	 *
+	 * @throws Exception Something went wrong!
+	 */
+	protected AdaptrisMessage newMessage() throws Exception
+	{
+		return newMessage(false);
+	}
+
+	/**
+	 * Create a new message, with either a default payload or the private key passphrase.
+	 *
+	 * @param passphrase If true, the payload will be the private key passphrase.
+	 *
+	 * @return A new message.
+	 *
+	 * @throws Exception Something went wrong!
+	 */
+	protected AdaptrisMessage newMessage(boolean passphrase) throws Exception
+	{
+		return AdaptrisMessageFactory.getDefaultInstance().newMessage(passphrase ? PASSPHRASE : MESSAGE, ENCODING);
+	}
+
+	/**
+	 * Create a new message, with the payload of the original.
+	 *
+	 * @param original The message to clone.
+	 *
+	 * @return A new message.
+	 *
+	 * @throws Exception Something went wrong!
+	 */
+	protected AdaptrisMessage newMessage(AdaptrisMessage original) throws Exception
+	{
+		AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(original.getPayload());
+		message.setContentEncoding(original.getContentEncoding());
+		return message;
+	}
+
+	/**
+	 * Get the ASCII armored private key.
+	 *
+	 * @param key The raw private key data.
+	 *
+	 * @return The ASCII armored key.
+	 *
+	 * @throws Exception Something went wrong!
+	 */
 	protected String getKey(PGPSecretKey key) throws Exception
 	{
 		ByteArrayOutputStream keyBytes = new ByteArrayOutputStream();
 		ArmoredOutputStream armored = new ArmoredOutputStream(keyBytes);
 		key.encode(armored);
 		armored.close();
-		return keyBytes.toString();
+		return keyBytes.toString(ENCODING);
 	}
 
+	/**
+	 * Get the ASCII armored public key.
+	 *
+	 * @param key The raw public key data.
+	 *
+	 * @return The ASCII armored key.
+	 *
+	 * @throws Exception Something went wrong!
+	 */
 	protected String getKey(PGPPublicKey key) throws Exception
 	{
 		ByteArrayOutputStream keyBytes = new ByteArrayOutputStream();
 		ArmoredOutputStream armored = new ArmoredOutputStream(keyBytes);
 		key.encode(armored);
 		armored.close();
-		return keyBytes.toString();
+		return keyBytes.toString(ENCODING);
 	}
 }

--- a/src/test/java/com/adaptris/security/pgp/PGPTests.java
+++ b/src/test/java/com/adaptris/security/pgp/PGPTests.java
@@ -5,6 +5,7 @@ import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.MultiPayloadAdaptrisMessage;
 import com.adaptris.core.MultiPayloadMessageFactory;
 import com.adaptris.core.ServiceCase;
+import com.adaptris.core.common.MultiPayloadByteArrayInputParameter;
 import com.adaptris.core.common.MultiPayloadStreamInputParameter;
 import com.adaptris.core.common.MultiPayloadStreamOutputParameter;
 import com.adaptris.core.common.MultiPayloadStringInputParameter;
@@ -209,8 +210,8 @@ abstract class PGPTests extends ServiceCase
 		}
 		else
 		{
-			keyParam = new MultiPayloadStreamInputParameter();
-			((MultiPayloadStreamInputParameter)keyParam).setPayloadId(PAYLOAD_KEY);
+			keyParam = new MultiPayloadByteArrayInputParameter();
+			((MultiPayloadByteArrayInputParameter)keyParam).setPayloadId(PAYLOAD_KEY);
 		}
 		return keyParam;
 	}


### PR DESCRIPTION
* remove references to character encoding (UTF-8) in the services; use message encoding where necessary
* force no encoding when copying bytes to stream