### PR TITLE
INTERLOK-3656 Fix unset/unused signature exception

### DIFF
--- a/src/main/java/com/adaptris/security/pgp/PGPDecryptService.java
+++ b/src/main/java/com/adaptris/security/pgp/PGPDecryptService.java
@@ -5,9 +5,6 @@ import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.common.MetadataStreamInputParameter;
-import com.adaptris.core.common.PayloadStreamInputParameter;
-import com.adaptris.core.common.PayloadStreamOutputParameter;
 import com.adaptris.interlok.config.DataInputParameter;
 import com.adaptris.interlok.config.DataOutputParameter;
 import com.adaptris.interlok.resolver.ExternalResolver;
@@ -76,19 +73,19 @@ public class PGPDecryptService extends PGPService
 
 	@NotNull
 	@Valid
-	private DataInputParameter privateKey = new MetadataStreamInputParameter();
+	private DataInputParameter privateKey;
 
 	@NotNull
 	@Valid
-	private DataInputParameter passphrase = new MetadataStreamInputParameter();
+	private DataInputParameter passphrase;
 
 	@NotNull
 	@Valid
-	private DataInputParameter cipherText = new PayloadStreamInputParameter();
+	private DataInputParameter cipherText;
 
 	@NotNull
 	@Valid
-	private DataOutputParameter clearText = new PayloadStreamOutputParameter();
+	private DataOutputParameter clearText;
 
 	/**
 	 * {@inheritDoc}.

--- a/src/main/java/com/adaptris/security/pgp/PGPEncryptService.java
+++ b/src/main/java/com/adaptris/security/pgp/PGPEncryptService.java
@@ -7,9 +7,6 @@ import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.common.MetadataStreamInputParameter;
-import com.adaptris.core.common.PayloadStreamInputParameter;
-import com.adaptris.core.common.PayloadStreamOutputParameter;
 import com.adaptris.interlok.config.DataInputParameter;
 import com.adaptris.interlok.config.DataOutputParameter;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -77,25 +74,25 @@ public class PGPEncryptService extends PGPService
 
 	@NotNull
 	@Valid
-	private DataInputParameter publicKey = new MetadataStreamInputParameter();
+	private DataInputParameter publicKey;
 
 	@NotNull
 	@Valid
-	private DataInputParameter clearText = new PayloadStreamInputParameter();
+	private DataInputParameter clearText;
 
 	@NotNull
 	@Valid
-	private DataOutputParameter cipherText = new PayloadStreamOutputParameter();
+	private DataOutputParameter cipherText;
 
 	@Valid
 	@AdvancedConfig
 	@InputFieldDefault(value = "true")
-	private Boolean armorEncoding = true;
+	private Boolean armorEncoding;
 
 	@Valid
 	@AdvancedConfig
 	@InputFieldDefault(value = "true")
-	private Boolean integrityCheck = true;
+	private Boolean integrityCheck;
 
 		/**
 	 * {@inheritDoc}.
@@ -109,7 +106,7 @@ public class PGPEncryptService extends PGPService
 			InputStream clear = extractStream(message, clearText, "Could not read clear text message to encrypt");
 			ByteArrayOutputStream cipher = new ByteArrayOutputStream();
 			String id = message.getUniqueId();
-			encrypt(id, clear, cipher, key, armorEncoding, integrityCheck);
+			encrypt(id, clear, cipher, key, armorEncoding(), integrityCheck());
 			insertStream(message, cipherText, cipher);
 		}
 		catch (Exception e)
@@ -310,5 +307,15 @@ public class PGPEncryptService extends PGPService
 		{
 			Arrays.fill(buf, (byte)0);
 		}
+	}
+
+	private boolean armorEncoding()
+	{
+		return BooleanUtils.toBooleanDefaultIfNull(armorEncoding, true);
+	}
+
+	private boolean integrityCheck()
+	{
+		return BooleanUtils.toBooleanDefaultIfNull(integrityCheck, true);
 	}
 }

--- a/src/main/java/com/adaptris/security/pgp/PGPService.java
+++ b/src/main/java/com/adaptris/security/pgp/PGPService.java
@@ -83,18 +83,26 @@ abstract class PGPService extends ServiceImp
 
 	protected InputStream extractStream(AdaptrisMessage message, DataInputParameter parameter, String warning) throws Exception
 	{
-		Object param = parameter.extract(message);
-		if (param instanceof String)
+		Object param = null;
+		try
 		{
-			param = new ByteArrayInputStream(((String)param).getBytes(getEncoding(message)));
+			param = parameter.extract(message);
+			if (param instanceof String)
+			{
+				param = new ByteArrayInputStream(((String)param).getBytes(getEncoding(message)));
+			}
+			if (param instanceof byte[])
+			{
+				param = new ByteArrayInputStream((byte[])param);
+			}
+			if (!(param instanceof InputStream))
+			{
+				throw new InterlokException(warning);
+			}
 		}
-		if (param instanceof byte[])
+		catch (Exception e)
 		{
-			param = new ByteArrayInputStream((byte[])param);
-		}
-		if (!(param instanceof InputStream))
-		{
-			throw new InterlokException(warning);
+			log.warn("Could not determine signature type; assuming inline", e);
 		}
 		return (InputStream)param;
 	}

--- a/src/main/java/com/adaptris/security/pgp/PGPService.java
+++ b/src/main/java/com/adaptris/security/pgp/PGPService.java
@@ -2,10 +2,10 @@ package com.adaptris.security.pgp;
 
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceImp;
+import com.adaptris.core.common.ByteArrayPayloadDataOutputParameter;
 import com.adaptris.core.common.InputStreamWithEncoding;
 import com.adaptris.core.common.PayloadStreamOutputParameter;
 import com.adaptris.core.common.StringPayloadDataOutputParameter;
-import com.adaptris.core.common.ByteArrayPayloadDataOutputParameter;
 import com.adaptris.interlok.InterlokException;
 import com.adaptris.interlok.config.DataInputParameter;
 import com.adaptris.interlok.config.DataOutputParameter;
@@ -83,26 +83,18 @@ abstract class PGPService extends ServiceImp
 
 	protected InputStream extractStream(AdaptrisMessage message, DataInputParameter parameter, String warning) throws Exception
 	{
-		Object param = null;
-		try
+		Object param = parameter.extract(message);
+		if (param instanceof String)
 		{
-			param = parameter.extract(message);
-			if (param instanceof String)
-			{
-				param = new ByteArrayInputStream(((String)param).getBytes(getEncoding(message)));
-			}
-			if (param instanceof byte[])
-			{
-				param = new ByteArrayInputStream((byte[])param);
-			}
-			if (!(param instanceof InputStream))
-			{
-				throw new InterlokException(warning);
-			}
+			param = new ByteArrayInputStream(((String)param).getBytes(getEncoding(message)));
 		}
-		catch (Exception e)
+		if (param instanceof byte[])
 		{
-			log.warn("Could not determine signature type; assuming inline", e);
+			param = new ByteArrayInputStream((byte[])param);
+		}
+		if (!(param instanceof InputStream))
+		{
+			throw new InterlokException(warning);
 		}
 		return (InputStream)param;
 	}

--- a/src/main/java/com/adaptris/security/pgp/PGPVerifyService.java
+++ b/src/main/java/com/adaptris/security/pgp/PGPVerifyService.java
@@ -5,9 +5,6 @@ import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.common.MetadataStreamInputParameter;
-import com.adaptris.core.common.PayloadStreamInputParameter;
-import com.adaptris.core.common.PayloadStreamOutputParameter;
 import com.adaptris.interlok.config.DataInputParameter;
 import com.adaptris.interlok.config.DataOutputParameter;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -67,17 +64,17 @@ public class PGPVerifyService extends PGPService
 
 	@NotNull
 	@Valid
-	private DataInputParameter publicKey = new MetadataStreamInputParameter();
+	private DataInputParameter publicKey;
 
 	@NotNull
 	@Valid
-	private DataInputParameter signedMessage = new PayloadStreamInputParameter();
+	private DataInputParameter signedMessage;
 
 	@Valid
-	private DataInputParameter signature = new MetadataStreamInputParameter();
+	private DataInputParameter signature;
 
 	@Valid
-	private DataOutputParameter originalMessage = new PayloadStreamOutputParameter();
+	private DataOutputParameter originalMessage;
 
 	/**
 	 * {@inheritDoc}.

--- a/src/main/java/com/adaptris/security/pgp/PGPVerifyService.java
+++ b/src/main/java/com/adaptris/security/pgp/PGPVerifyService.java
@@ -95,7 +95,7 @@ public class PGPVerifyService extends PGPService
 				sig = extractStream(message, signature, "Could not read signature to verify");
 			}
 			ByteArrayOutputStream original = new ByteArrayOutputStream();
-			if (signature != null)
+			if (sig != null)
 			{
 				verify(data, sig, key, original);
 			}

--- a/src/test/java/com/adaptris/security/pgp/PGPEncryptionTests.java
+++ b/src/test/java/com/adaptris/security/pgp/PGPEncryptionTests.java
@@ -1,19 +1,15 @@
 package com.adaptris.security.pgp;
 
-import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.MultiPayloadAdaptrisMessage;
-import com.adaptris.core.common.*;
-import com.adaptris.interlok.config.DataInputParameter;
-import com.adaptris.interlok.config.DataOutputParameter;
-import org.bouncycastle.bcpg.ArmoredOutputStream;
-import org.bouncycastle.openpgp.PGPPublicKey;
-import org.bouncycastle.openpgp.PGPSecretKey;
+import com.adaptris.core.common.ConstantDataInputParameter;
+import com.adaptris.core.common.MultiPayloadByteArrayInputParameter;
+import com.adaptris.core.common.MultiPayloadStringInputParameter;
+import com.adaptris.core.common.MultiPayloadStringOutputParameter;
+import com.adaptris.core.common.PayloadStreamInputParameter;
 import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.fail;
-
-import java.io.ByteArrayOutputStream;
 
 public class PGPEncryptionTests extends PGPTests
 {
@@ -206,7 +202,7 @@ public class PGPEncryptionTests extends PGPTests
 		}
 	}
 
-	private PGPEncryptService getEncryptService(boolean armor, boolean integrity) throws Exception
+	private PGPEncryptService getEncryptService(boolean armor, boolean integrity)
 	{
 		PGPEncryptService service = new PGPEncryptService();
 		service.setPublicKey(getKeyInput(armor));
@@ -219,7 +215,7 @@ public class PGPEncryptionTests extends PGPTests
 		return service;
 	}
 
-	private PGPDecryptService getDecryptService(String passphrase, boolean armor) throws Exception
+	private PGPDecryptService getDecryptService(String passphrase, boolean armor)
 	{
 		PGPDecryptService service = new PGPDecryptService();
 		service.setPrivateKey(getKeyInput(armor));
@@ -234,12 +230,6 @@ public class PGPEncryptionTests extends PGPTests
 	@Override
 	protected Object retrieveObjectForSampleConfig()
 	{
-		return new PGPEncryptService();
+		return getEncryptService(true, true);
 	}
-
-    @Override
-    public boolean isAnnotatedForJunit4()
-    {
-        return true;
-    }
 }

--- a/src/test/java/com/adaptris/security/pgp/PGPSignatureTests.java
+++ b/src/test/java/com/adaptris/security/pgp/PGPSignatureTests.java
@@ -1,12 +1,14 @@
 package com.adaptris.security.pgp;
 
-import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.MultiPayloadAdaptrisMessage;
-import com.adaptris.core.common.*;
+import com.adaptris.core.common.ConstantDataInputParameter;
+import com.adaptris.core.common.MultiPayloadStreamInputParameter;
+import com.adaptris.core.common.MultiPayloadStreamOutputParameter;
+import com.adaptris.core.common.MultiPayloadStringInputParameter;
+import com.adaptris.core.common.MultiPayloadStringOutputParameter;
+import com.adaptris.core.common.PayloadStreamInputParameter;
 import com.adaptris.interlok.config.DataInputParameter;
 import com.adaptris.interlok.config.DataOutputParameter;
-import org.bouncycastle.openpgp.PGPPublicKey;
-import org.bouncycastle.openpgp.PGPSecretKey;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -249,7 +251,7 @@ public class PGPSignatureTests extends PGPTests
 		}
 	}
 
-	private PGPSignService getSignService(String passphrase, boolean detached, boolean armor) throws Exception
+	private PGPSignService getSignService(String passphrase, boolean detached, boolean armor)
 	{
 		PGPSignService service = new PGPSignService();
 		service.setPrivateKey(getKeyInput(armor));
@@ -272,7 +274,7 @@ public class PGPSignatureTests extends PGPTests
 		return service;
 	}
 
-	private PGPVerifyService getVerifyService(boolean detached, boolean armor) throws Exception
+	private PGPVerifyService getVerifyService(boolean detached, boolean armor)
 	{
 		PGPVerifyService service = new PGPVerifyService();
 		service.setPublicKey(getKeyInput(armor));
@@ -302,12 +304,6 @@ public class PGPSignatureTests extends PGPTests
 	@Override
 	protected Object retrieveObjectForSampleConfig()
 	{
-		return new PGPSignService();
+		return getVerifyService(false, true);
 	}
-
-    @Override
-    public boolean isAnnotatedForJunit4()
-    {
-        return true;
-    }
 }

--- a/src/test/java/com/adaptris/security/pgp/PGPTests.java
+++ b/src/test/java/com/adaptris/security/pgp/PGPTests.java
@@ -1,18 +1,15 @@
 package com.adaptris.security.pgp;
 
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.MultiPayloadAdaptrisMessage;
 import com.adaptris.core.MultiPayloadMessageFactory;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.common.MultiPayloadByteArrayInputParameter;
 import com.adaptris.core.common.MultiPayloadByteArrayOutputParameter;
 import com.adaptris.core.common.MultiPayloadStreamInputParameter;
-import com.adaptris.core.common.MultiPayloadStreamOutputParameter;
 import com.adaptris.core.common.MultiPayloadStringInputParameter;
 import com.adaptris.core.common.MultiPayloadStringOutputParameter;
 import com.adaptris.interlok.config.DataInputParameter;
 import com.adaptris.interlok.config.DataOutputParameter;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 import org.bouncycastle.bcpg.ArmoredOutputStream;
 import org.bouncycastle.bcpg.HashAlgorithmTags;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -34,7 +31,7 @@ import java.security.KeyPairGenerator;
 import java.security.Security;
 import java.util.Date;
 
-abstract class PGPTests extends ServiceCase
+abstract class PGPTests extends ExampleServiceCase
 {
 	protected static final String MESSAGE = "Spicy jalapeno bacon ipsum dolor amet shankle hamburger tri-tip, filet mignon ham sirloin prosciutto pig andouille pork belly pork loin. Tail beef kielbasa alcatra salami doner turkey corned beef fatback leberkas pastrami shoulder spare ribs filet mignon pork loin. Cupim doner pastrami chicken venison pork loin. Ribeye pork tri-tip cow buffalo rump boudin sirloin short ribs picanha salami." + System.getProperty("line.separator");
 	protected static final String PASSPHRASE = "passphrase";


### PR DESCRIPTION
When using an inline signature, the signature field in the verify service should (ideally be null) but otherwise can be a null metadata key.

## Motivation

Discovered a bug (NPE) when verifying an inline signature. If you leave the signature field empty/null it defaults to a metadata input parameter. Now as long as we're aware of this we can handle it and assume that the signature is inline and not separate from the payload.

## Modification

Catch exception if there is no usable signature, and then process the payload as if the signature is inlined.

## Result

PGP verification of inline signatures should now work.

## Testing

Use the new pgp-testing project in Gitlb - it's how I found the bug and confirmed that it's now working.
